### PR TITLE
Fix TypeError on empty Speed_Out and harden dictionary access

### DIFF
--- a/custom_components/bayernluefter/fan.py
+++ b/custom_components/bayernluefter/fan.py
@@ -84,16 +84,18 @@ class BayernluefterFan(BayernluefterEntity, FanEntity):
     @property
     def percentage(self) -> int:
         """Return the speed of the fan-"""
+        # Added "or 0" to handle NoneType return from get()
         return ranged_value_to_percentage(
-            FAN_SPEED_RANGE, self._device.data.get("Speed_Out", 0)
+            FAN_SPEED_RANGE, self._device.data.get("Speed_Out") or 0
         )
 
     @property
     def preset_mode(self) -> str | None:
         """Return the current preset mode."""
-        if self._device.data["TimerActiv"]:
+        # Changed direct dict access to .get() to prevent KeyError
+        if self._device.data.get("TimerActiv"):
             pm = FanMode.Timer
-        elif self._device.data["SpeedFrozen"]:
+        elif self._device.data.get("SpeedFrozen"):
             pm = None
         else:
             pm = FanMode.Auto


### PR DESCRIPTION
Hi! 👋

I created this PR to fix a TypeError that occurs when the API returns None for Speed_Out, and to make the property access more robust against missing keys.

Changes:

Fix TypeError in percentage: The ranged_value_to_percentage helper failed because self._device.data.get("Speed_Out", 0) returns None if the key exists but the value is null.

Fix: Added or 0 to ensure an integer is always passed.

Harden preset_mode: Changed direct dictionary access (["Key"]) to .get("Key") in preset_mode. This prevents potential KeyError crashes if the API response is incomplete during initialization or connection issues.

Context: Found and verified on Home Assistant Core 2026.1.0 (tested in production).

Thanks for your work on this integration!